### PR TITLE
perf: optimise `Intents` usage.

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -21,9 +21,13 @@ presence = interactions.ClientPresence(
 bot = interactions.Client(
     TOKEN,
     intents=(
-        interactions.Intents.DEFAULT
-        | interactions.Intents.GUILD_MESSAGE_CONTENT
+        interactions.Intents.GUILDS
         | interactions.Intents.GUILD_MEMBERS
+        | interactions.Intents.GUILD_BANS
+        | interactions.Intents.GUILD_MESSAGES
+        | interactions.Intents.DIRECT_MESSAGES # commands can work in DMs too.
+        | interactions.Intents.GUILD_MESSAGE_CONTENT
+        | interactions.Intents.GUILDS
     ),
     disable_sync=True
 )


### PR DESCRIPTION
This commit uses the intent integer flags appropriate for all operations ran in Astro. `Intents.DEFAULT` is an inefficient way of allowing the library to continue dispatching events which can serve as a computational burden. For most use cases, it's fine to pass this default but in our situation we want to make Astro as fast as humanly possible.