### PR TITLE
fix: add ellipsis at end of shortened content

### DIFF
--- a/src/exts/message.py
+++ b/src/exts/message.py
@@ -101,7 +101,7 @@ class Message(interactions.Extension):
                 if short_content.count("__") % 2 == 1
                 else f"{content[:1020]}_..."
                 if short_content.count("_") % 2 == 1
-                else short_content
+                else f"{short_content}..."
             )
         else:
             _content = content


### PR DESCRIPTION
I forgot to add the `...` at the end of the shortened content, whoops.
I swear this is the last one.