### PR TITLE
fix: `min_values` and `max_values` when selecting tags

### DIFF
--- a/src/exts/message.py
+++ b/src/exts/message.py
@@ -126,8 +126,8 @@ class Message(interactions.Extension):
             custom_id="TAG_SELECTION",
             placeholder="Select the tags you want",
             options=_options,
-            min_values=0,
-            max_values=len(_options),
+            min_values=1,
+            max_values=5,
         )
 
         thread = interactions.Channel(**_thread, _client=self.bot._http)

--- a/src/exts/message.py
+++ b/src/exts/message.py
@@ -61,7 +61,7 @@ class Message(interactions.Extension):
         ):
             return await ctx.send("missing permissions!", ephemeral=True)
         await self.bot._http.modify_channel(
-            channel_id=int(ctx.channel_id), payload={"applied_tags": _selected}
+            channel_id=int(ctx.channel_id), payload={"applied_tags": _selected if "remove_all_tags" not in _selected else []}
         )
         await ctx.send("Done", ephemeral=True)
 
@@ -121,6 +121,15 @@ class Message(interactions.Extension):
             )
             for tag in _tags
         ]
+        _options.append(
+            interactions.SelectOption(
+                label="remove all tags",
+                value="remove_all_tags",
+                emoji=interactions.Emoji(
+                    name="🗑",
+                ),
+            ),
+        )
 
         select = interactions.SelectMenu(
             custom_id="TAG_SELECTION",


### PR DESCRIPTION
Currently, I think the `min_values` should be 1, since from this behaviour, if none of any option is chosen, the bot will be offline for a while (?) and thus, interaction failed.

![image](https://user-images.githubusercontent.com/60958064/185760879-7de8ac0c-99d6-40d7-bc82-7764c892401f.png)


For `max_values`, it should be limit to 5, as when I tested it with 6 options chosen, the bot refused to edit the forum tags, thus, interaction failed.

![image](https://user-images.githubusercontent.com/60958064/185760898-42afb7b8-d274-462b-a9bf-88bcf51a3eef.png)
![image](https://user-images.githubusercontent.com/60958064/185760901-dd02fd00-79cd-4c13-b351-6e1867f426ec.png)
![image](https://user-images.githubusercontent.com/60958064/185760903-e4cb661c-bd6b-486f-8cfc-5473386a9375.png)
![image](https://user-images.githubusercontent.com/60958064/185760904-b0b05b40-944b-4281-8215-872e733f360e.png)
