### PR TITLE
PersistentCustomID for edited name in tag edit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 discord-py-interactions >= 4.3.1
 interactions-wait-for>=1.0.6
 dinteractions-Paginator >= 2.0.2
+interactions-persistence>=2.2.2
 python-dotenv==0.20.0
 aiohttp~=3.8.1
 pymongo[srv]

--- a/src/bot.py
+++ b/src/bot.py
@@ -41,7 +41,7 @@ bot = interactions.Client(
 )
 setup(bot)
 monkeypatch(bot)
-
+bot.load("interactions.ext.persistence")
 
 [bot.load(f"src.exts.{ext}", db=db) for ext in EXTENSIONS]
 


### PR DESCRIPTION
This use PersistentCustomID instead of class attribute for edited name in tag edit as it might get messed up if more than 1 people trying to edit a tag at the same time.