### PR TITLE
Ping roles

### DIFF
--- a/exts/roles.py
+++ b/exts/roles.py
@@ -37,18 +37,8 @@ class Roles(naff.Extension):
             "To what roles do you want to (un)subscribe to? (default only main library changelogs)",
             choices=[
                 naff.SlashCommandChoice(
-                    name="Only Main Library Changelogs",
+                    name="Library Changelogs",
                     value=str(METADATA["roles"]["Changelog pings"]),
-                ),
-                naff.SlashCommandChoice(
-                    name="Only External Library Changelogs",
-                    value=str(METADATA["roles"]["External Changelog pings"]),
-                ),
-                naff.SlashCommandChoice(
-                    name="Both Changelogs",
-                    value=(
-                        f"{METADATA['roles']['Changelog pings']} {METADATA['roles']['External Changelog pings']}"
-                    ),
                 ),
                 naff.SlashCommandChoice(
                     name="Polls Pings",

--- a/exts/roles.py
+++ b/exts/roles.py
@@ -54,6 +54,10 @@ class Roles(naff.Extension):
                     name="Polls Pings",
                     value=str(METADATA["roles"]["Polls pings"]),
                 ),
+                naff.SlashCommandChoice(
+                    name="Server News",
+                    value=str(METADATA["roles"]["Server news"]),
+                ),
             ],
             default=str(METADATA["roles"]["Changelog pings"]),
         ),


### PR DESCRIPTION
Adds `server news` ping role and removes `ext changelog` ping role due to channel refactor 